### PR TITLE
fix lazy minting

### DIFF
--- a/contracts/VWBL.sol
+++ b/contracts/VWBL.sol
@@ -1,0 +1,102 @@
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/interfaces/IERC2981.sol";
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+abstract contract VWBLProtocol is ERC721Enumerable, IERC2981 {
+    uint256 public counter = 0;
+    struct TokenInfo {
+        address minterAddress;
+        string getKeyURl;
+    }
+
+    struct RoyaltyInfo {
+        address recipient;
+        uint256 royaltiesPercentage;
+    }
+
+    mapping(uint256 => TokenInfo) public tokenIdToTokenInfo;
+    mapping(uint256 => RoyaltyInfo) public tokenIdToRoyaltyInfo;
+
+    function transfer(address to, uint256 tokenId) public {
+        _transfer(msg.sender, to, tokenId);
+    }
+
+    function safeTransfer(address to, uint256 tokenId) public {
+        _safeTransfer(msg.sender, to, tokenId, "");
+    }
+
+    function mint(address _minter, string memory _getKeyURl, uint256 _royaltiesPercentage) public virtual returns (uint256) {
+        uint256 tokenId = ++counter;
+        tokenIdToTokenInfo[tokenId].minterAddress = _minter;
+        tokenIdToTokenInfo[tokenId].getKeyURl = _getKeyURl;
+        _mint(_minter, tokenId);
+        if (_royaltiesPercentage > 0) {
+            _setRoyalty(tokenId, _minter, _royaltiesPercentage);
+        }
+        return tokenId;
+    }
+
+    function getTokenByMinter(address minter)
+        public
+        view
+        returns (TokenInfo[] memory)
+    {
+        uint256 currentCounter = 0;
+        TokenInfo[] memory tokens = new TokenInfo[](counter);
+        for (uint256 i = 1; i <= counter; i++) {
+            if (tokenIdToTokenInfo[i].minterAddress == minter) {
+                tokens[currentCounter] = tokenIdToTokenInfo[i];
+            }
+        }
+        return tokens;
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view
+        virtual override(IERC165, ERC721Enumerable) returns (bool) {
+            return interfaceId == type(IERC2981).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
+    function royaltyInfo(uint256 _tokenId, uint256 _salePrice)
+        external
+        view
+        override
+        returns (address receiver, uint256 royaltyAmount)
+    {
+        RoyaltyInfo memory royaltyInfo = tokenIdToRoyaltyInfo[_tokenId];
+        uint256 _royalties = (_salePrice * royaltyInfo.royaltiesPercentage) / 100;
+        return (royaltyInfo.recipient, _royalties);
+    }
+
+    function _setRoyalty(
+        uint256 _tokenId,
+        address _recipient,
+        uint256 _royaltiesPercentage
+    ) internal {
+        RoyaltyInfo storage royaltyInfo = tokenIdToRoyaltyInfo[_tokenId];
+        royaltyInfo.recipient = _recipient;
+        royaltyInfo.royaltiesPercentage = _royaltiesPercentage;
+    }
+}
+
+contract VWBL is VWBLProtocol, Ownable {
+    string public baseURI;
+
+    constructor(
+        string memory _baseURI
+    ) ERC721("VWBL", "VWBL") {
+        baseURI = _baseURI;
+    }
+
+    function _baseURI() internal view override returns (string memory) {
+        return baseURI;
+    }
+
+    function setBaseURI(string memory _baseURI) public onlyOwner {
+        baseURI = _baseURI;
+    }
+}

--- a/contracts/lazy-minting/EIP712Adaptor.sol
+++ b/contracts/lazy-minting/EIP712Adaptor.sol
@@ -1,0 +1,81 @@
+pragma solidity ^0.8.0;
+pragma abicoder v2; // required to accept structs as function parameters
+
+import "@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "./VWBLLazySupport.sol";
+
+contract EIP712Adaptor is EIP712, AccessControl, VWBLLazySupport {
+    bytes32 public constant SIGNER_ROLE = keccak256("SIGNER_ROLE");
+    string private constant SIGNING_DOMAIN = "LazyNFT-Voucher";
+    string private constant SIGNATURE_VERSION = "1";
+
+    constructor(string memory _baseURI, address _vwblLazyMintingContract, address _signer) 
+        VWBLLazySupport(_baseURI, _vwblLazyMintingContract) 
+        EIP712(SIGNING_DOMAIN, SIGNATURE_VERSION)
+    {
+        _setupRole(SIGNER_ROLE, _signer);
+    }
+
+    /// @notice Represents an un-minted NFT, which has not yet been recorded into the blockchain. A signed voucher can be redeemed for a real NFT using the redeem function.
+    struct NFTVoucher {
+        // @notice The address who NFT minted.
+        address minter;
+        // @notice The random string of the token to be redeemed. Must be unique - if another token with this randomString already exists, the redeem function will revert.
+        string randomString;
+        // @notice The minimum price (in wei) that the NFT creator is willing to accept for the initial sale of this NFT.
+        uint256 minPrice;
+        // @notice The metadata URI to associate with this token.
+        string uri;
+        // @notice Percentage of each sale to pay as royalties.
+        uint256 royaltiesPercentage;
+        // @notice the EIP-712 signature of all other fields in the NFTVoucher struct. For a voucher to be valid, it must be signed by an account with the SIGNER_ROLE.
+        bytes signature;
+    }
+
+    /// @notice Returns a hash of the given NFTVoucher, prepared using EIP712 typed data hashing rules.
+    /// @param voucher An NFTVoucher to hash.
+    function _hash(NFTVoucher calldata voucher) internal view returns (bytes32) {
+        return
+            _hashTypedDataV4(
+                keccak256(
+                    abi.encode(
+                        keccak256(
+                            "NFTVoucher(address minter,string randomString,uint256 minPrice,string uri,uint256 royaltiesPercentage)"
+                        ),
+                        voucher.minter,
+                        voucher.randomString,
+                        voucher.minPrice,
+                        keccak256(bytes(voucher.uri)),
+                        voucher.royaltiesPercentage
+                    )
+                )
+            );
+    }
+
+    /// @notice Returns the chain id of the current blockchain.
+    /// @dev This is used to workaround an issue with ganache returning different values from the on-chain chainid() function and
+    ///  the eth_chainId RPC method. See https://github.com/protocol/nft-website/issues/121 for context.
+    function getChainID() external view returns (uint256) {
+        uint256 id;
+        assembly {
+            id := chainid()
+        }
+        return id;
+    }
+
+    /// @notice Verifies the signature for a given NFTVoucher, returning the address of the signer.
+    /// @dev Will revert if the signature is invalid. Does not verify that the signer is authorized to mint NFTs.
+    /// @param voucher An NFTVoucher describing an unminted NFT.
+    function _verify(NFTVoucher calldata voucher) internal view returns (address) {
+        bytes32 digest = _hash(voucher);
+        return ECDSA.recover(digest, voucher.signature);
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view
+        virtual override(AccessControl, VWBLProtocol) returns (bool) {
+            return AccessControl.supportsInterface(interfaceId) ||
+                super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/lazy-minting/VWBLLazyMinting.sol
+++ b/contracts/lazy-minting/VWBLLazyMinting.sol
@@ -1,0 +1,79 @@
+pragma solidity ^0.8.0;
+pragma abicoder v2; // required to accept structs as function parameters
+
+import "./EIP712Adaptor.sol";
+
+contract VWBLLazyMinting is EIP712Adaptor {
+    mapping(address => uint256) public pendingWithdrawals;
+    string[] public randomStringArray;
+
+    constructor(address _signer, string memory _baseURI) EIP712Adaptor(_baseURI, address(this), _signer) {}
+
+    /// @notice Redeems an NFTVoucher for an actual NFT, creating it in the process.
+    /// @param redeemer The address of the account which will receive the NFT upon success.
+    /// @param voucher A signed NFTVoucher that describes the NFT to be redeemed.
+    function redeem(address redeemer, NFTVoucher calldata voucher) public payable returns (uint256) {
+        // make sure signature is valid and get the address of the signer
+        address signer = _verify(voucher);
+
+        // make sure that the signer is authorized to mint NFTs
+        require(
+            hasRole(SIGNER_ROLE, signer),
+            "Invalid Signature"
+        );
+
+        // make sure that the redeemer is paying enough to cover the buyer's cost
+        require(msg.value >= voucher.minPrice, "Insufficient funds to redeem");
+
+        // make sure that the randomString of token is not minted
+        bool alreadyMinted = mintedRandomstring(voucher.randomString);
+        require(alreadyMinted == false, "Already minted");
+
+        // first assign the token to the minter, to establish provenance on-chain
+        mint(voucher.minter, voucher.uri, voucher.royaltiesPercentage);
+
+        // transfer the token to the redeemer
+        _transfer(voucher.minter, redeemer, counter);
+
+        // push randomString to array
+        randomStringArray.push(voucher.randomString);
+
+        // record payment to minter's withdrawal balance
+        pendingWithdrawals[voucher.minter] += msg.value;
+
+        return counter;
+    }
+
+    /// @notice Transfers all pending withdrawal balance to the caller. Reverts if the caller is not an authorized minter.
+    function withdraw() public {
+        //IMPORTANT: casting msg.sender to a payable address is only safe if ALL members of the minter role are payable addresses.
+        address payable minter = payable(msg.sender);
+
+        uint256 amount = pendingWithdrawals[minter];
+        // zero account before transfer to prevent re-entrancy attack
+        pendingWithdrawals[minter] = 0;
+        minter.transfer(amount);
+    }
+
+    /// @notice Retuns the amount of Ether available to the caller to withdraw.
+    function availableToWithdraw() public view returns (uint256) {
+        return pendingWithdrawals[msg.sender];
+    }
+
+    function mintedRandomstring(string memory randomString) public view returns (bool) {
+        for (uint32 i = 0; i < randomStringArray.length; i++) {
+            if (hashCompareWithLengthCheck(randomString, randomStringArray[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function hashCompareWithLengthCheck(string memory a, string memory b) private pure returns (bool) {
+        if(bytes(a).length != bytes(b).length) {
+            return false;
+        } else {
+            return keccak256(abi.encodePacked(a)) == keccak256(abi.encodePacked(b));
+        }
+    }
+}

--- a/contracts/lazy-minting/VWBLLazySupport.sol
+++ b/contracts/lazy-minting/VWBLLazySupport.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.8.0;
+import "../VWBL.sol";
+
+contract VWBLLazySupport is VWBL {
+    address vwblLazyMintingContract;
+
+    constructor(
+        string memory _baseURI,
+        address _vwblLazyMintingContract
+    ) VWBL(_baseURI) {
+        vwblLazyMintingContract = _vwblLazyMintingContract;
+    }
+
+    function mint(address _minter, string memory _getKeyURl, uint256 _royaltiesPercentage) public override returns (uint256) {
+        require(msg.sender == vwblLazyMintingContract, "msg.sender is invalid");
+        uint256 tokenId = ++counter;
+        tokenIdToTokenInfo[tokenId].minterAddress = _minter;
+        tokenIdToTokenInfo[tokenId].getKeyURl = _getKeyURl;
+        _mint(_minter, tokenId);
+        if (_royaltiesPercentage > 0) {
+            _setRoyalty(tokenId, _minter, _royaltiesPercentage);
+        }
+        return tokenId;
+    }
+}

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,0 +1,121 @@
+/**
+ * Use this file to configure your truffle project. It's seeded with some
+ * common settings for different networks and features like migrations,
+ * compilation and testing. Uncomment the ones you need or modify
+ * them to suit your project as necessary.
+ *
+ * More information about configuration can be found at:
+ *
+ * trufflesuite.com/docs/advanced/configuration
+ *
+ * To deploy via Infura you'll need a wallet provider (like @truffle/hdwallet-provider)
+ * to sign your transactions before they're sent to a remote public node. Infura accounts
+ * are available for free at: infura.io/register.
+ *
+ * You'll also need a mnemonic - the twelve word phrase the wallet uses to generate
+ * public/private key pairs. If you're publishing your code to GitHub make sure you load this
+ * phrase from a file you've .gitignored so it doesn't accidentally become public.
+ *
+ */
+
+// const HDWalletProvider = require('@truffle/hdwallet-provider');
+//
+// const fs = require('fs');
+// const mnemonic = fs.readFileSync(".secret").toString().trim();
+
+module.exports = {
+  /**
+   * Networks define how you connect to your ethereum client and let you set the
+   * defaults web3 uses to send transactions. If you don't specify one truffle
+   * will spin up a development blockchain for you on port 9545 when you
+   * run `develop` or `test`. You can ask a truffle command to use a specific
+   * network from the command line, e.g
+   *
+   * $ truffle test --network <network-name>
+   */
+
+  networks: {
+    // Useful for testing. The `development` name is special - truffle uses it by default
+    // if it's defined here and no other network is specified at the command line.
+    // You should run a client (like ganache-cli, geth or parity) in a separate terminal
+    // tab if you use this network and you must also set the `host`, `port` and `network_id`
+    // options below to some value.
+    //
+    development: {
+     host: "127.0.0.1",     // Localhost (default: none)
+     port: 8545,            // Standard Ethereum port (default: none)
+     network_id: "*",       // Any network (default: none)
+     gas: 8721974
+    },
+    // Another network with more advanced options...
+    // advanced: {
+    // port: 8777,             // Custom port
+    // network_id: 1342,       // Custom network
+    // gas: 8500000,           // Gas sent with each transaction (default: ~6700000)
+    // gasPrice: 20000000000,  // 20 gwei (in wei) (default: 100 gwei)
+    // from: <address>,        // Account to send txs from (default: accounts[0])
+    // websocket: true        // Enable EventEmitter interface for web3 (default: false)
+    // },
+    // Useful for deploying to a public network.
+    // NB: It's important to wrap the provider as a function.
+    // ropsten: {
+    // provider: () => new HDWalletProvider(mnemonic, `https://ropsten.infura.io/v3/YOUR-PROJECT-ID`),
+    // network_id: 3,       // Ropsten's id
+    // gas: 5500000,        // Ropsten has a lower block limit than mainnet
+    // confirmations: 2,    // # of confs to wait between deployments. (default: 0)
+    // timeoutBlocks: 200,  // # of blocks before a deployment times out  (minimum/default: 50)
+    // skipDryRun: true     // Skip dry run before migrations? (default: false for public nets )
+    // },
+    // Useful for private networks
+    // private: {
+    // provider: () => new HDWalletProvider(mnemonic, `https://network.io`),
+    // network_id: 2111,   // This network is yours, in the cloud.
+    // production: true    // Treats this network as if it was a public net. (default: false)
+    // }
+  },
+
+  // Set default mocha options here, use special reporters etc.
+  mocha: {
+    // timeout: 100000
+  },
+
+  // Configure your compilers
+  compilers: {
+    solc: {
+      version: "0.8.11",    // Fetch exact version from solc-bin (default: truffle's version)
+      // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
+      settings: {          // See the solidity docs for advice about optimization and evmVersion
+        optimizer: {
+          enabled: true,
+          runs: 200
+        }
+      //  evmVersion: "byzantium"
+      }
+    }
+  },
+
+  plugins: [
+    'truffle-contract-size'
+  ]
+
+  // Truffle DB is currently disabled by default; to enable it, change enabled:
+  // false to enabled: true. The default storage location can also be
+  // overridden by specifying the adapter settings, as shown in the commented code below.
+  //
+  // NOTE: It is not possible to migrate your contracts to truffle DB and you should
+  // make a backup of your artifacts to a safe location before enabling this feature.
+  //
+  // After you backed up your artifacts you can utilize db by running migrate as follows:
+  // $ truffle migrate --reset --compile-all
+  //
+  // db: {
+    // enabled: false,
+    // host: "127.0.0.1",
+    // adapter: {
+    //   name: "sqlite",
+    //   settings: {
+    //     directory: ".db"
+    //   }
+    // }
+  // }
+};


### PR DESCRIPTION

- 一つの`VWBLLazyMinting`コントラクトで複数のminterがmint可能にするために、署名データNFTVoucherのフィールドにminterを追加しました。
- UXを向上させるため、NFT作成者(minter)がNFTVoucherの署名するのではなく、オフチェーンマーケットを運営するサーバ管理者(signer)が署名するように変更しました。
- VWBL.solのmint関数のパラメータにminterを追加しました。UIは変更する必要は無いと思いますが、フロントエンドでtx送信者(msg.sender)をパラメータに追加する処理の追加をお願いします。
- デプロイ時のエラーはコントラクト分割とcompilerの最適化(truffle-config.js)をすることで対処しました。