### PR TITLE
Fix: change TokenInfo's variants order

### DIFF
--- a/contracts/access-condition/ERC1155/VWBLERC1155.sol
+++ b/contracts/access-condition/ERC1155/VWBLERC1155.sol
@@ -23,8 +23,8 @@ contract VWBLERC1155 is IERC2981, Ownable, ERC1155Enumerable, ERC1155Burnable {
     uint256 public counter = 0;
 
     struct TokenInfo {
-        address minterAddress;
         bytes32 documentId;
+        address minterAddress;
         string getKeyURl;
     }
 
@@ -116,8 +116,8 @@ contract VWBLERC1155 is IERC2981, Ownable, ERC1155Enumerable, ERC1155Burnable {
         bytes32 _documentId
     ) public payable returns (uint256) {
         uint256 tokenId = ++counter;
-        tokenIdToTokenInfo[tokenId].minterAddress = msg.sender;
         tokenIdToTokenInfo[tokenId].documentId = _documentId;
+        tokenIdToTokenInfo[tokenId].minterAddress = msg.sender;
         tokenIdToTokenInfo[tokenId].getKeyURl = _getKeyURl;
         _mint(msg.sender, tokenId, _amount, "");
         if (_royaltiesPercentage > 0) {
@@ -155,8 +155,8 @@ contract VWBLERC1155 is IERC2981, Ownable, ERC1155Enumerable, ERC1155Burnable {
         for (uint32 i = 0; i < _amounts.length; i++) {
             uint256 tokenId = ++counter;
             tokenIds[i] = tokenId;
-            tokenIdToTokenInfo[tokenId].minterAddress = msg.sender;
             tokenIdToTokenInfo[tokenId].documentId = _documentIds[i];
+            tokenIdToTokenInfo[tokenId].minterAddress = msg.sender;
             tokenIdToTokenInfo[tokenId].getKeyURl = _getKeyURl;
             if (_royaltiesPercentages[i] > 0) {
                 _setRoyalty(tokenId, msg.sender, _royaltiesPercentages[i]);

--- a/contracts/access-condition/ERC1155/extensions/VWBLERC1155Metadata.sol
+++ b/contracts/access-condition/ERC1155/extensions/VWBLERC1155Metadata.sol
@@ -165,8 +165,8 @@ contract VWBLERC1155Metadata is IERC2981, Ownable, ERC1155Enumerable, ERC1155Bur
         for (uint32 i = 0; i < _amounts.length; i++) {
             uint256 tokenId = ++counter;
             tokenIds[i] = tokenId;
-            tokenIdToTokenInfo[tokenId].minterAddress = msg.sender;
             tokenIdToTokenInfo[tokenId].documentId = _documentIds[i];
+            tokenIdToTokenInfo[tokenId].minterAddress = msg.sender;
             tokenIdToTokenInfo[tokenId].getKeyURl = _getKeyURl;
             _tokenURIs[tokenId] = _metadataURl;
             if (_royaltiesPercentages[i] > 0) {


### PR DESCRIPTION
VWBLERC1155のTokenInfoとVWBL(NFT)のTokenInfoの配列が異なっていたので、NFT側のTokenInfoの順番に合わせました。

現状ERC1155のコントラクトは使われていないので変えても大丈夫と判断したのと、
tokenIdToTokenInfoを叩いた時に帰ってくるデータの順番が違ったら良くないと思ったのでPRを出しておきます。