### PR TITLE
Fix: contract's sign message

### DIFF
--- a/config/.env.mumbai
+++ b/config/.env.mumbai
@@ -5,6 +5,6 @@ METADATA_URL=https://xxx.yyy.zzz
 #Set your NFT's sign message
 MESSAGE_TO_BE_SIGNED=Hello VWBL
 #Set your Munbai's API URL (ex. Alchemy API URL)
-MUNBAI_URL=
+MUMBAI_URL=
 #Set your private key
 PRIVATE_KEY=

--- a/contracts/access-condition/ERC1155/IVWBLERC1155.sol
+++ b/contracts/access-condition/ERC1155/IVWBLERC1155.sol
@@ -46,7 +46,7 @@ interface IVWBLERC1155 {
     function getMinter(uint256 tokenId) external view returns (address);
 
     /**
-     * @notice Get signature of this contract
+     * @notice Get a message to be signed of this contract
      */
-    function getSignature() external view returns (string memory);
+    function getSignMessage() external view returns (string memory);
 }

--- a/contracts/access-condition/ERC1155/VWBLERC1155.sol
+++ b/contracts/access-condition/ERC1155/VWBLERC1155.sol
@@ -25,7 +25,7 @@ contract VWBLERC1155 is IERC2981, Ownable, ERC1155Enumerable, ERC1155Burnable {
     address public accessCheckerContract;
 
     uint256 public counter = 0;
-    string private signature;
+    string private signMessage;
 
     struct TokenInfo {
         bytes32 documentId;
@@ -49,12 +49,12 @@ contract VWBLERC1155 is IERC2981, Ownable, ERC1155Enumerable, ERC1155Burnable {
         string memory _baseURI,
         address _gatewayProxy,
         address _accessCheckerContract,
-        string memory _signature
+        string memory _signMessage
     ) ERC1155(_baseURI) {
         setBaseURI(_baseURI);
         gatewayProxy = _gatewayProxy;
         accessCheckerContract = _accessCheckerContract;
-        signature = _signature;
+        signMessage = _signMessage;
     }
 
     function _beforeTokenTransfer(
@@ -263,16 +263,16 @@ contract VWBLERC1155 is IERC2981, Ownable, ERC1155Enumerable, ERC1155Burnable {
     }
 
     /**
-     * @notice Get signature of this contract
+     * @notice Get the message to be signed of this contract
      */
-    function getSignature() public view returns (string memory) {
-        return signature;
+    function getSignMessage() public view returns (string memory) {
+        return signMessage;
     }
 
     /**
-     * @notice Set signature of this contract
+     * @notice Set the message to be signed of this contract
      */
-    function setSignature(string calldata _signature) public onlyOwner {
-        signature = _signature;
+    function setSignMessage(string calldata _signMessage) public onlyOwner {
+        signMessage = _signMessage;
     }
 }

--- a/contracts/access-condition/ERC721/IVWBL.sol
+++ b/contracts/access-condition/ERC721/IVWBL.sol
@@ -30,7 +30,7 @@ interface IVWBL {
     function getMinter(uint256 tokenId) external view returns (address);
 
     /**
-     * @notice Get signature of this contract
+     * @notice Get a message to be signed of this contract
      */
-    function getSignature() external view returns (string memory);
+    function getSignMessage() external view returns (string memory);
 }

--- a/contracts/access-condition/ERC721/VWBL.sol
+++ b/contracts/access-condition/ERC721/VWBL.sol
@@ -112,7 +112,7 @@ contract VWBL is VWBLProtocol, Ownable, IVWBL {
     string public baseURI;
     address public gatewayProxy;
     address public accessCheckerContract;
-    string private signature;
+    string private signMessage;
 
     event accessCheckerContractChanged(address oldAccessCheckerContract, address newAccessCheckerContract);
 
@@ -120,12 +120,12 @@ contract VWBL is VWBLProtocol, Ownable, IVWBL {
         string memory _baseURI,
         address _gatewayProxy,
         address _accessCheckerContract,
-        string memory _signature
+        string memory _signMessage
     ) ERC721("VWBL", "VWBL") {
         baseURI = _baseURI;
         gatewayProxy = _gatewayProxy;
         accessCheckerContract = _accessCheckerContract;
-        signature = _signature;
+        signMessage = _signMessage;
     }
 
     /**
@@ -201,16 +201,16 @@ contract VWBL is VWBLProtocol, Ownable, IVWBL {
     }
 
     /**
-     * @notice Get signature of this contract
+     * @notice Get the message to be signed of this contract
      */
-    function getSignature() public view returns (string memory) {
-        return signature;
+    function getSignMessage() public view returns (string memory) {
+        return signMessage;
     }
 
     /**
-     * @notice Set signature of this contract
+     * @notice Set the message to be signed of this contract
      */
-    function setSignature(string calldata _signature) public onlyOwner {
-        signature = _signature;
+    function setSignMessage(string calldata _signMessage) public onlyOwner {
+        signMessage = _signMessage;
     }
 }

--- a/contracts/access-condition/ERC721/extensions/IVWBLMetadata.sol
+++ b/contracts/access-condition/ERC721/extensions/IVWBLMetadata.sol
@@ -32,7 +32,7 @@ interface IVWBLMetadata {
     function getMinter(uint256 tokenId) external view returns (address);
 
     /**
-     * @notice Get signature of this contract
+     * @notice Get the message to be signed of this contract
      */
-    function getSignature() external view returns (string memory);
+    function getSignMessage() external view returns (string memory);
 }

--- a/contracts/access-condition/ERC721/extensions/VWBLMetadata.sol
+++ b/contracts/access-condition/ERC721/extensions/VWBLMetadata.sol
@@ -122,18 +122,18 @@ abstract contract VWBLProtocol is ERC721Enumerable, IERC2981 {
 contract VWBLMetadata is VWBLProtocol, Ownable, IVWBLMetadata {
     address public gatewayProxy;
     address public accessCheckerContract;
-    string private signature;
+    string private signMessage;
 
     event accessCheckerContractChanged(address oldAccessCheckerContract, address newAccessCheckerContract);
 
     constructor(
         address _gatewayProxy,
         address _accessCheckerContract,
-        string memory _signature
+        string memory _signMessage
     ) ERC721("VWBL", "VWBL") {
         gatewayProxy = _gatewayProxy;
         accessCheckerContract = _accessCheckerContract;
-        signature = _signature;
+        signMessage = _signMessage;
     }
 
     /**
@@ -196,16 +196,16 @@ contract VWBLMetadata is VWBLProtocol, Ownable, IVWBLMetadata {
     }
 
     /**
-     * @notice Get signature of this contract
+     * @notice Get the message to be signed of this contract
      */
-    function getSignature() public view returns (string memory) {
-        return signature;
+    function getSignMessage() public view returns (string memory) {
+        return signMessage;
     }
 
     /**
-     * @notice Set signature of this contract
+     * @notice Set the message to be signed of this contract
      */
-    function setSignature(string calldata _signature) public onlyOwner {
-        signature = _signature;
+    function setSignMessage(string calldata _signMessage) public onlyOwner {
+        signMessage = _signMessage;
     }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "deploy": "hardhat run scripts/deploy.ts",
     "deploy:local": "hardhat run --network localhost scripts/deploy.ts",
     "deploy:polygon": "env-cmd -f ./config/.env.polygon hardhat run --network polygon scripts/deploy.ts",
-    "deploy:munbai": "env-cmd -f ./config/.env.munbai hardhat run --network munbai scripts/deploy.ts",
+    "deploy:mumbai": "env-cmd -f ./config/.env.mumbai hardhat run --network mumbai scripts/deploy.ts",
     "deploy:ethereum": "env-cmd -f ./config/.env.ethereum hardhat run --network ethereum scripts/deploy.ts",
     "deploy:goerli": "env-cmd -f ./config/.env.goerli hardhat run --network goerli scripts/deploy.ts",
     "deploy:aurora": "env-cmd -f ./config/.env.aurora hardhat run --network aurora scripts/deploy.ts",

--- a/test/vwbl_getter.test.ts
+++ b/test/vwbl_getter.test.ts
@@ -22,13 +22,13 @@ describe("Getter function", function () {
         const nftChecker = await AccessControlCheckerByNFT.deploy(gatewayProxy.address)
         const VWBLNFT = await ethers.getContractFactory("VWBL")
         const vwblNFT_1 = await VWBLNFT.deploy(baseURI, gatewayProxy.address, nftChecker.address, "Hello, VWBL")
-        const vwblNFT_2 = await VWBLNFT.deploy(baseURI, gatewayProxy.address, nftChecker.address, "Hello, VWBL")
+        const vwblNFT_2 = await VWBLNFT.deploy(baseURI, gatewayProxy.address, nftChecker.address, "Hello, VWBL {{nonce}}")
         // VWBL ERC1155
         const AccessControlCheckerByERC1155 = await ethers.getContractFactory("AccessControlCheckerByERC1155")
         const erc1155Checker = await AccessControlCheckerByERC1155.deploy(gatewayProxy.address)
         const VWBLERC1155 = await ethers.getContractFactory("VWBLERC1155")
         const vwblERC1155_1 = await VWBLERC1155.deploy(baseURI, gatewayProxy.address, erc1155Checker.address, "Hello, VWBL")
-        const vwblERC1155_2 = await VWBLERC1155.deploy(baseURI, gatewayProxy.address, erc1155Checker.address, "Hello, VWBL")
+        const vwblERC1155_2 = await VWBLERC1155.deploy(baseURI, gatewayProxy.address, erc1155Checker.address, "Hello, VWBL {{nonce}}")
         return {
             vwblGateway,
             vwblNFT_1,
@@ -154,14 +154,47 @@ describe("Getter function", function () {
             // getNFTDatas
             const nftDatas = await nftChecker.getNFTDatas()
             const nftDocumentIds = nftDatas[0]
-            console.log("nftDocumentIds", nftDocumentIds)
+            // console.log("nftDocumentIds", nftDocumentIds)
             expect(nftDocumentIds.length).to.equal(6)
 
             // getERC1155Datas
             const erc1155Datas = await erc1155Checker.getERC1155Datas()
             const erc1155DocumentIds = erc1155Datas[0]
-            console.log("erc1155DocumentIds", erc1155DocumentIds)
+            // console.log("erc1155DocumentIds", erc1155DocumentIds)
             expect(erc1155DocumentIds.length).to.equal(6)
         })
+
+    describe("Sign Message", function () {
+        it("Should message to be signed of contracts successfully get", async function () {
+            const {
+                vwblNFT_1,
+                vwblNFT_2,
+                vwblERC1155_1,
+                vwblERC1155_2
+            } = await loadFixture(deployTokenFixture)
+            expect(await vwblNFT_1.getSignMessage()).to.equal("Hello, VWBL")
+            expect(await vwblNFT_2.getSignMessage()).to.equal("Hello, VWBL {{nonce}}")
+            expect(await vwblERC1155_1.getSignMessage()).to.equal("Hello, VWBL")
+            expect(await vwblERC1155_2.getSignMessage()).to.equal("Hello, VWBL {{nonce}}")
+        })
+
+        it("Should message to be signed of contracts successfully change", async function () {
+            const {
+                owner,
+                vwblNFT_1,
+                vwblERC1155_1,
+            } = await loadFixture(deployTokenFixture)
+            const sampleSignMessge1 = "vwblNFT_1 {{nonce}}"
+            const sampleSignMessge2 = "vwblERC1155_1 {{nonce}}"
+
+            // change sign message
+            await vwblNFT_1.connect(owner).setSignMessage(sampleSignMessge1)
+            await vwblERC1155_1.connect(owner).setSignMessage(sampleSignMessge2)
+
+            // check sign message
+            expect(await vwblNFT_1.getSignMessage()).to.equal(sampleSignMessge1)
+            expect(await vwblERC1155_1.getSignMessage()).to.equal(sampleSignMessge2)
+        })
+    })
     })
 })


### PR DESCRIPTION
## やったこと
- signatureだとミスリーディングにつながるのでsign messageに修正
- テストコードの追加（getSignMessge, setSignMessage）
- その他タイポミスの修正（munbai→mumbai）